### PR TITLE
Fix Auth0 redirect loop with dedicated callback route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,13 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
+import { RequireAuth } from "@/components/RequireAuth";
+import { RedirectIfAuthed } from "@/components/RedirectIfAuthed";
+import Callback from "./pages/Callback";
 import Dashboard from "./pages/Dashboard";
 import Home from "./pages/Home";
+import Index from "./pages/Index";
 import Landing from "./pages/Landing";
 import SignIn from "./pages/SignIn";
 import SignUp from "./pages/SignUp";
@@ -17,17 +21,65 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/landing" element={<Landing />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/sign-in" element={<SignIn />} />
-          <Route path="/sign-up" element={<SignUp />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+      <Routes>
+          <Route path="/" element={<Navigate to="/landing" replace />} />
+          
+          {/* Public routes - redirect to dashboard if authenticated */}
+          <Route path="/callback" element={<Callback />} />
+          <Route
+            path="/landing"
+            element={
+              <RedirectIfAuthed>
+                <Landing />
+              </RedirectIfAuthed>
+            }
+          />
+          <Route
+            path="/sign-in"
+            element={
+              <RedirectIfAuthed>
+                <SignIn />
+              </RedirectIfAuthed>
+            }
+          />
+          <Route
+            path="/sign-up"
+            element={
+              <RedirectIfAuthed>
+                <SignUp />
+              </RedirectIfAuthed>
+            }
+          />
+          
+          {/* Protected routes - require authentication */}
+          <Route
+            path="/home"
+            element={
+              <RequireAuth>
+                <Home />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/dashboard"
+            element={
+              <RequireAuth>
+                <Dashboard />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/research"
+            element={
+              <RequireAuth>
+                <Index />
+              </RequireAuth>
+            }
+          />
+          
+          {/* Catch-all route */}
           <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      </Routes>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/frontend/src/components/RedirectIfAuthed.tsx
+++ b/frontend/src/components/RedirectIfAuthed.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth0 } from "@auth0/auth0-react";
+
+interface RedirectIfAuthedProps {
+  children: ReactNode;
+}
+
+export const RedirectIfAuthed = ({ children }: RedirectIfAuthedProps) => {
+  const { isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+};
+

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,34 @@
+import { useEffect, ReactNode } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+export const RequireAuth = ({ children }: RequireAuthProps) => {
+  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      loginWithRedirect();
+    }
+  }, [isLoading, isAuthenticated, loginWithRedirect]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,17 +1,40 @@
 import { createRoot } from "react-dom/client";
-import { Auth0Provider } from "@auth0/auth0-react";
+import { BrowserRouter } from "react-router-dom";
+import { Auth0Provider, AppState } from "@auth0/auth0-react";
+import { useNavigate } from "react-router-dom";
 import App from "./App.tsx";
 import "./index.css";
 
+const redirectUri = import.meta.env.VITE_AUTH0_REDIRECT_URI || window.location.origin + "/callback";
+
+const Auth0ProviderWithNavigate = ({ children }: { children: React.ReactNode }) => {
+  const navigate = useNavigate();
+
+  const onRedirectCallback = (appState?: AppState) => {
+    navigate(appState?.returnTo ?? "/dashboard", { replace: true });
+  };
+
+  return (
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: redirectUri,
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE || undefined,
+      }}
+      onRedirectCallback={onRedirectCallback}
+      cacheLocation="localstorage"
+      useRefreshTokens={true}
+    >
+      {children}
+    </Auth0Provider>
+  );
+};
+
 createRoot(document.getElementById("root")!).render(
-  <Auth0Provider
-    domain={import.meta.env.VITE_AUTH0_DOMAIN}
-    clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-    authorizationParams={{
-      redirect_uri: import.meta.env.VITE_AUTH0_REDIRECT_URI,
-      audience: import.meta.env.VITE_AUTH0_AUDIENCE || undefined,
-    }}
-  >
-    <App />
-  </Auth0Provider>
+  <BrowserRouter>
+    <Auth0ProviderWithNavigate>
+      <App />
+    </Auth0ProviderWithNavigate>
+  </BrowserRouter>
 );

--- a/frontend/src/pages/Callback.tsx
+++ b/frontend/src/pages/Callback.tsx
@@ -1,0 +1,13 @@
+const Callback = () => {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+        <p className="text-muted-foreground">Signing you in…</p>
+      </div>
+    </div>
+  );
+};
+
+export default Callback;
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,38 +1,9 @@
-import { useEffect } from "react";
-import { useAuth0 } from "@auth0/auth0-react";
+import { Link } from "react-router-dom";
 import { AuthButtons } from "@/components/AuthButtons";
+import { Button } from "@/components/ui/button";
+import { Home, Microscope, LayoutDashboard } from "lucide-react";
 
 const Dashboard = () => {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
-
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      loginWithRedirect();
-    }
-  }, [isLoading, isAuthenticated, loginWithRedirect]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Redirecting to login...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen p-6">
       <div className="max-w-4xl mx-auto">
@@ -40,6 +11,31 @@ const Dashboard = () => {
           <h1 className="text-3xl font-bold">Dashboard</h1>
           <AuthButtons />
         </div>
+        
+        <div className="bg-card rounded-lg border p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">Navigation</h2>
+          <div className="flex flex-wrap gap-3">
+            <Link to="/home">
+              <Button variant="outline" className="gap-2">
+                <Home className="w-4 h-4" />
+                Home
+              </Button>
+            </Link>
+            <Link to="/research">
+              <Button variant="outline" className="gap-2">
+                <Microscope className="w-4 h-4" />
+                Research
+              </Button>
+            </Link>
+            <Link to="/dashboard">
+              <Button variant="outline" className="gap-2">
+                <LayoutDashboard className="w-4 h-4" />
+                Dashboard
+              </Button>
+            </Link>
+          </div>
+        </div>
+        
         <div className="bg-card rounded-lg border p-6">
           <h2 className="text-xl font-semibold mb-4">Protected Content</h2>
           <p className="text-muted-foreground">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { AuthButtons } from "@/components/AuthButtons";
 import { Button } from "@/components/ui/button";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, LayoutDashboard, Microscope, Home } from "lucide-react";
 
 const Home = () => {
   return (
@@ -15,11 +15,17 @@ const Home = () => {
         <div className="flex flex-col gap-4 items-center pt-6">
           <AuthButtons />
           
-          <div className="pt-4">
+          <div className="pt-4 flex flex-wrap gap-3 justify-center">
             <Link to="/dashboard">
-              <Button variant="link" className="gap-2">
-                Go to Dashboard
-                <ArrowRight className="w-4 h-4" />
+              <Button variant="outline" className="gap-2">
+                <LayoutDashboard className="w-4 h-4" />
+                Dashboard
+              </Button>
+            </Link>
+            <Link to="/research">
+              <Button variant="outline" className="gap-2">
+                <Microscope className="w-4 h-4" />
+                Research
               </Button>
             </Link>
           </div>

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,142 +1,22 @@
-import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { Mail, Lock, ArrowRight, Chrome } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { KnowledgeGraph } from "@/components/background/KnowledgeGraph";
-import { useAuth } from "@/contexts/AuthContext";
+import { useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const SignIn = () => {
-  const navigate = useNavigate();
-  const { signIn } = useAuth();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  const { loginWithRedirect, isLoading } = useAuth0();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    const success = await signIn(email, password);
-    setIsLoading(false);
-    if (success) {
-      navigate("/dashboard");
+  useEffect(() => {
+    if (!isLoading) {
+      loginWithRedirect({
+        appState: { returnTo: "/dashboard" },
+      });
     }
-  };
-
-  const handleOAuth = async () => {
-    setIsLoading(true);
-    await signIn("demo@example.com", "demo");
-    setIsLoading(false);
-    navigate("/dashboard");
-  };
+  }, [isLoading, loginWithRedirect]);
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-6 relative overflow-hidden">
-      {/* Background */}
-      <div className="fixed inset-0 pointer-events-none opacity-[0.04]">
-        <KnowledgeGraph />
-      </div>
-
-      <div className="relative z-10 w-full max-w-md">
-        {/* Logo */}
-        <Link to="/landing" className="block text-center mb-8">
-          <h1 className="text-3xl font-bold">
-            <span className="text-foreground">Re</span>
-            <span className="text-primary glow-text">Search</span>
-            <span className="text-foreground">ly</span>
-          </h1>
-        </Link>
-
-        <Card className="glass-card border-glass-border/50">
-          <CardHeader className="text-center pb-4">
-            <CardTitle className="text-2xl">Welcome back</CardTitle>
-            <CardDescription>
-              Sign in to continue your research
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* OAuth Buttons */}
-            <div className="grid grid-cols-1 gap-3">
-              <Button
-                variant="outline"
-                className="w-full border-glass-border hover:bg-secondary/50"
-                onClick={() => handleOAuth()}
-              >
-                <Chrome className="w-4 h-4 mr-2" />
-                Continue with Google
-              </Button>
-            </div>
-
-            <div className="relative">
-              <Separator />
-              <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-3 text-xs text-muted-foreground">
-                or
-              </span>
-            </div>
-
-            {/* Email Form */}
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="you@example.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="pl-10 bg-secondary/50 border-glass-border"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password">Password</Label>
-                  <Link 
-                    to="#" 
-                    className="text-xs text-primary hover:underline"
-                  >
-                    Forgot password?
-                  </Link>
-                </div>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="••••••••"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="pl-10 bg-secondary/50 border-glass-border"
-                    required
-                  />
-                </div>
-              </div>
-
-              <Button 
-                type="submit" 
-                className="w-full group" 
-                disabled={isLoading}
-              >
-                {isLoading ? "Signing in..." : "Sign In"}
-                <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-1" />
-              </Button>
-            </form>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Don't have an account?{" "}
-              <Link to="/sign-up" className="text-primary hover:underline">
-                Sign up
-              </Link>
-            </p>
-          </CardContent>
-        </Card>
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+        <p className="text-muted-foreground">Redirecting to login…</p>
       </div>
     </div>
   );

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,161 +1,25 @@
-import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { Mail, Lock, User, ArrowRight, Chrome } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { KnowledgeGraph } from "@/components/background/KnowledgeGraph";
-import { useAuth } from "@/contexts/AuthContext";
+import { useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const SignUp = () => {
-  const navigate = useNavigate();
-  const { signUp } = useAuth();
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  const { loginWithRedirect, isLoading } = useAuth0();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    const success = await signUp(name, email, password);
-    setIsLoading(false);
-    if (success) {
-      navigate("/dashboard");
+  useEffect(() => {
+    if (!isLoading) {
+      loginWithRedirect({
+        appState: { returnTo: "/dashboard" },
+        authorizationParams: {
+          screen_hint: "signup",
+        },
+      });
     }
-  };
-
-  const handleOAuth = async () => {
-    setIsLoading(true);
-    await signUp("Demo User", "demo@example.com", "demo");
-    setIsLoading(false);
-    navigate("/dashboard");
-  };
+  }, [isLoading, loginWithRedirect]);
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-6 relative overflow-hidden">
-      {/* Background */}
-      <div className="fixed inset-0 pointer-events-none opacity-[0.04]">
-        <KnowledgeGraph />
-      </div>
-
-      <div className="relative z-10 w-full max-w-md">
-        {/* Logo */}
-        <Link to="/landing" className="block text-center mb-8">
-          <h1 className="text-3xl font-bold">
-            <span className="text-foreground">Re</span>
-            <span className="text-primary glow-text">Search</span>
-            <span className="text-foreground">ly</span>
-          </h1>
-        </Link>
-
-        <Card className="glass-card border-glass-border/50">
-          <CardHeader className="text-center pb-4">
-            <CardTitle className="text-2xl">Create your account</CardTitle>
-            <CardDescription>
-              Start your research journey today
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* OAuth Buttons */}
-            <div className="grid grid-cols-1 gap-3">
-              <Button
-                variant="outline"
-                className="w-full border-glass-border hover:bg-secondary/50"
-                onClick={() => handleOAuth()}
-              >
-                <Chrome className="w-4 h-4 mr-2" />
-                Continue with Google
-              </Button>
-            </div>
-
-            <div className="relative">
-              <Separator />
-              <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-card px-3 text-xs text-muted-foreground">
-                or
-              </span>
-            </div>
-
-            {/* Email Form */}
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="name">Full Name</Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    id="name"
-                    type="text"
-                    placeholder="Jane Researcher"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    className="pl-10 bg-secondary/50 border-glass-border"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="you@example.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="pl-10 bg-secondary/50 border-glass-border"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="••••••••"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="pl-10 bg-secondary/50 border-glass-border"
-                    required
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Must be at least 8 characters
-                </p>
-              </div>
-
-              <Button 
-                type="submit" 
-                className="w-full group" 
-                disabled={isLoading}
-              >
-                {isLoading ? "Creating account..." : "Create Account"}
-                <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-1" />
-              </Button>
-            </form>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Already have an account?{" "}
-              <Link to="/sign-in" className="text-primary hover:underline">
-                Sign in
-              </Link>
-            </p>
-
-            <p className="text-center text-xs text-muted-foreground">
-              By signing up, you agree to our{" "}
-              <Link to="#" className="text-primary hover:underline">Terms</Link>
-              {" "}and{" "}
-              <Link to="#" className="text-primary hover:underline">Privacy Policy</Link>
-            </p>
-          </CardContent>
-        </Card>
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+        <p className="text-muted-foreground">Redirecting to sign up…</p>
       </div>
     </div>
   );


### PR DESCRIPTION
what was broken:
- Auth0 login caused a redirect loop back to `/landing`
- Users were authenticated but bounced instead of landing on `/dashboard`
- Root cause was missing and inconsistent callback handling

what I fixed:
- Added a dedicated `/callback` route to handle Auth0 redirects
- Centralized post-login navigation to `/dashboard`
- Introduced `RequireAuth` and `RedirectIfAuthed` guards
- Fixed Auth0 redirect config to avoid landing-page bounce

result:
- Login works reliably (including incognito)
- No redirect loops
- Protected routes behave correctly
- Routing issue reported earlier is resolved

some and important notes :)
- Requires `VITE_AUTH0_REDIRECT_URI=http://localhost:8080/callback`
- Auth0 dashboard updated to allow `/callback`